### PR TITLE
Add unlayer-elements skill (code-first templates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ npx skills add unlayer/unlayer-skills
 | Skill | Description |
 |-------|-------------|
 | `unlayer` | Router — identifies the right sub-skill for your question |
-| `unlayer-integration` | Add Unlayer to React, Vue, Angular, or plain JavaScript |
+| `unlayer-integration` | Add the drag-and-drop editor to React, Vue, Angular, or plain JavaScript |
+| `unlayer-elements` | Build emails, pages, and documents in code with React components (no visual editor) |
 | `unlayer-custom-tools` | Build custom drag-and-drop tools and property editors |
 | `unlayer-export` | Export HTML, PDF, images, or save/load designs |
 | `unlayer-config` | Configure features, appearance, security, and dynamic content |
@@ -30,6 +31,8 @@ npx skills add unlayer/unlayer-skills
 
 ```
 "How do I add Unlayer to my React app?"
+"Build a welcome email in code with Unlayer Elements"
+"Generate an email template from React components and render it to HTML"
 "Create a custom tool with a color picker and text input"
 "Export my design as HTML and save the design JSON"
 "Set up merge tags for my email templates"

--- a/unlayer-elements/SKILL.md
+++ b/unlayer-elements/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: unlayer-elements
+description: Build emails, pages, and documents in code with @unlayer/react-elements — React components that render to email-safe (table) HTML, responsive web HTML, or print/PDF. Use when generating templates programmatically without the visual editor.
+---
+
+# Build with Unlayer Elements (code-first)
+
+## Overview
+
+`@unlayer/react-elements` is a set of React components for building emails, pages, and documents **in code** — no visual editor. Write JSX once and render it to:
+
+- **email** — table-based HTML (Outlook/Gmail/Yahoo safe)
+- **web** — responsive div/flexbox HTML
+- **document** — print / PDF-optimized HTML
+
+The output is a faithful reproduction of what the Unlayer editor produces, so designs round-trip into the editor as JSON. Full SSR support (Next.js, Remix, `renderToString`).
+
+### When to use this skill vs the editor
+
+| You want to… | Use |
+|---|---|
+| Generate/assemble templates **in code** (AI generation, programmatic emails, design systems) | **this skill** (`@unlayer/react-elements`) |
+| Embed a **drag-and-drop visual editor** in your app | `unlayer-integration` |
+| Export HTML/PDF from a saved design / Cloud API | `unlayer-export` |
+
+## Install
+
+```bash
+npm view @unlayer/react-elements version   # verify the published version first
+npm install @unlayer/react-elements
+```
+
+> This skill is written for `@unlayer/react-elements` **0.1.9+** and uses only forms verified against it. Always pass **canonical prop shapes** (object `fontFamily`, string sizes, etc.) — they work in every version.
+
+## Mental model — the structure is strict
+
+```
+<Email> | <Page> | <Document>        ← root wrapper, sets the render mode
+  <Row layout={ColumnLayouts.X}>     ← layout container; column count MUST match the layout
+    <Column>                         ← only Columns go directly in a Row
+      <Heading /> <Paragraph />      ← items only inside Columns (no nesting)
+      <Button /> <Image /> ...
+```
+
+- `<Email>` = email mode, `<Page>` = web, `<Document>` = print. They thread the mode to all children.
+- A `<Row>` takes `layout={ColumnLayouts.TwoEqual}` (or `cells={[1,1]}`) and must contain exactly the matching number of `<Column>` children.
+- Items (`Heading`, `Paragraph`, `Button`, `Image`, `Divider`, `Social`, `Menu`, `Table`, `Video`, `Html`) go **inside** Columns, never directly in a Row.
+
+## Render
+
+```tsx
+import { renderToHtml, renderToJson } from '@unlayer/react-elements';
+
+const html = renderToHtml(<Email>…</Email>);   // final HTML string (no hydration markers)
+const json = renderToJson(<Email>…</Email>);   // Unlayer design JSON (import into the editor)
+```
+
+## Complete example
+
+```tsx
+import {
+  Email, Row, Column, ColumnLayouts,
+  Heading, Paragraph, Button,
+} from '@unlayer/react-elements';
+
+const sans = { label: 'Sans', value: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif" };
+
+export function Welcome() {
+  return (
+    <Email backgroundColor="#F6F9FC" contentWidth="600px" fontFamily={sans} previewText="You're all set — get started inside.">
+      <Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="32px 40px 8px 40px">
+        <Column>
+          <Heading headingType="h4" fontSize="12px" fontWeight={700} color="#635BFF" letterSpacing="0.08em">
+            WELCOME
+          </Heading>
+          <Heading headingType="h1" fontSize="30px" fontWeight={700} color="#1A1F36" lineHeight="120%">
+            You're all set.
+          </Heading>
+          <Paragraph html="Everything's ready — here's how to get started." fontSize="16px" color="#697386" lineHeight="155%" />
+        </Column>
+      </Row>
+      <Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="16px 40px 36px 40px">
+        <Column>
+          <Button href="https://example.com" backgroundColor="#635BFF" color="#FFFFFF"
+            fontSize="16px" fontWeight={600} padding="14px 28px" borderRadius="8px" textAlign="center">
+            Get started
+          </Button>
+        </Column>
+      </Row>
+    </Email>
+  );
+}
+```
+
+## Critical conventions — use canonical shapes
+
+These shapes work in every version. Non-canonical forms (a string `fontFamily`, a bare-number `fontSize`) are not reliable.
+
+- **fontFamily is an object**: `{ label, value }`, e.g. `{ label: 'Arial', value: 'arial, sans-serif' }`. Define it once and reuse.
+- **fontWeight is a number** (`700`). **fontSize / padding / lineHeight / letterSpacing are strings** with units: `fontSize="28px"`, `padding="20px 40px"` (and `"0px"`, never `"0"`), `lineHeight="150%"` (or unitless `"1.5"`), `letterSpacing="0.08em"`.
+- **Big numbers / amounts must be `<Heading>`, never `<Paragraph>`** — a paragraph's margin scales with font size and balloons the layout.
+- **Column count must match the Row layout** (`TwoEqual` → exactly 2 `<Column>`), or the row renders empty.
+- **Inline formatting goes in `<Paragraph html="…">`** with real tags (`<b>`, `<a href>`). Heading/Paragraph **children must be a plain string** — passing JSX with tags as children does not render correctly. Use `html` for anything formatted.
+- **`previewText`** on the root shows inbox preview text in the rendered email HTML.
+
+## Image sizing — match Unlayer's model
+
+`src` is a URL string **or** `{ url, width?, height? }`, where **`width`/`height` are the image's NATURAL size**, not a display width.
+
+- **Default is responsive** — the image fills its column, capped at its natural size. `<Image src="…" />` or `<Image src={{ url, width: 400, height: 260 }} />` both render responsively. Provide the natural `width`/`height` when you know them.
+- **For a fixed display size, set it on the src object as `autoWidth:false` + `maxWidth` (a percent of the container):**
+  ```tsx
+  <Image src={{ url: 'https://…', autoWidth: false, maxWidth: '50%' }} altText="…" />
+  ```
+- **Heads-up:** large / hero images currently render at up to ~500px wide and won't go fully edge-to-edge — center them on the background.
+
+## Making it actually look good
+
+Agent-generated emails often look cheap. To make them genuinely nice:
+
+- **Never use `<Table headers={…} data={…}>` for a details list or line items.** The shorthand renders a bordered, zero-padding spreadsheet. Build **label/value rows** instead — a muted label left, a bold value right, separated by a hairline using the Column's `border` object:
+
+  ```tsx
+  const HAIRLINE = { borderBottomWidth: '1px', borderBottomStyle: 'solid', borderBottomColor: '#EBEBEB' };
+  function detailRow(label: string, value: string, last = false) {
+    const cell = { padding: '14px 0', border: last ? undefined : HAIRLINE };
+    return (
+      <Row layout={ColumnLayouts.TwoEqual} backgroundColor="#FFFFFF" padding="0 40px">
+        <Column {...cell}><Paragraph html={label} fontSize="14px" color="#717171" /></Column>
+        <Column {...cell}><Paragraph html={`<b>${value}</b>`} fontSize="14px" color="#222222" textAlign="right" /></Column>
+      </Row>
+    );
+  }
+  // call it inline: {detailRow('Total', '$1,248.00', true)} — NOT <detailRow/>;
+  // a Row must be a direct child of the root, so a section helper must return a <Row>.
+  ```
+
+- Use the brand's **real palette**; put white content rows on a light-gray `Email backgroundColor` for a card feel.
+- Add an **eyebrow**: a small uppercase `<Heading fontSize="12px" fontWeight={700} letterSpacing="0.08em">` in an accent color above the headline.
+- Generous, consistent **40–48px horizontal padding** and intentional vertical rhythm. Solid brand CTA with `borderRadius` ~8–10px.
+- **Full-width button** (when you want one) — set the display width on `size` via the escape hatch:
+  ```tsx
+  <Button values={{ size: { autoWidth: false, width: '100%' } }} href="…" backgroundColor="…" color="#FFFFFF"
+    fontSize="16px" fontWeight={700} padding="14px 28px" borderRadius="8px" textAlign="center">Get started</Button>
+  ```
+
+## Component quick reference
+
+`Email`/`Page`/`Document` (`backgroundColor`, `contentWidth`, `fontFamily`, `textColor`, `previewText`) · `Row` (`layout`/`cells`, `backgroundColor`, `padding`) · `Column` (`padding`, `backgroundColor`, `borderRadius`, `border`) · `Heading` (`headingType` h1–h6 / `level`, `text`/string children, `fontSize`, `fontWeight`, `color`, `lineHeight`, `letterSpacing`, `textAlign`, `fontFamily`) · `Paragraph` (`html` or string children/`text`) · `Button` (`href`, `backgroundColor`, `color`, `padding`, `borderRadius`, `textAlign`; `size` via `values` for a fixed width) · `Image` (`src` string or object, `altText`, `action`) · `Divider` (`borderTop*`) · `Social` (`icons={[{name,url}]}`) · `Menu` (`items={[{text,href}]}`) · `Table` (`headers`/`data` — for real tabular data only) · `Video` (`videoUrl`) · `Html` (`html`).
+
+See `references/component-reference.md` for full prop tables and `references/patterns.md` for ready-to-use section recipes.
+
+## Out of scope
+
+This skill is the **code-first** library. For the drag-and-drop **visual editor** SDK, see `unlayer-integration`; for export/Cloud API, see `unlayer-export`.

--- a/unlayer-elements/references/component-reference.md
+++ b/unlayer-elements/references/component-reference.md
@@ -1,0 +1,124 @@
+# Unlayer Elements — Component Reference
+
+All components import from `@unlayer/react-elements`. Use the **canonical prop shapes** below — they work in every published version (`0.1.9+`).
+
+## Root wrappers — `Email` / `Page` / `Document`
+
+Set the render mode (`Email` = email/tables, `Page` = web/flexbox, `Document` = print/PDF) and thread it to all children.
+
+| Prop | Type | Notes |
+|---|---|---|
+| `backgroundColor` | string | `"#F7F8F9"` |
+| `contentWidth` | string | `"600px"` (an email also adds a small gutter each side) |
+| `contentAlign` | string | `"center"` |
+| `fontFamily` | `{ label, value }` | **object**, e.g. `{ label: "Arial", value: "arial,helvetica,sans-serif" }` |
+| `textColor` | string | base text color |
+| `previewText` | string | inbox preview text shown in the rendered email HTML |
+| `linkStyle` | object | `{ linkColor, linkHoverColor, linkUnderline, linkHoverUnderline }` |
+
+## Layout — `Row` / `Column`
+
+`Row`
+| Prop | Type | Notes |
+|---|---|---|
+| `layout` | `ColumnLayout` | `ColumnLayouts.OneColumn` … `FiveEqual`, `TwoWideNarrow`, etc. |
+| `cells` | `number[]` | alternative to `layout`, e.g. `[2, 1]` = 67% / 33% |
+| `backgroundColor` | string | |
+| `padding` | string | `"20px 40px"`, `"0px"` (always include `px`) |
+| `noStackMobile` | boolean | keep columns side-by-side on mobile |
+
+`Column`
+| Prop | Type | Notes |
+|---|---|---|
+| `padding` | string | inner padding |
+| `backgroundColor` | string | |
+| `borderRadius` | string | `"8px"` |
+| `border` | object | `{ borderBottomWidth, borderBottomStyle, borderBottomColor, … }` — per-side; great for hairline dividers |
+
+### ColumnLayouts
+
+`OneColumn` `[1]` · `TwoEqual` `[1,1]` · `TwoWideNarrow` `[2,1]` · `TwoNarrowWide` `[1,2]` · `ThreeEqual` `[1,1,1]` · `ThreeNarrowWideNarrow` `[1,2,1]` · `FourEqual` · `FiveEqual`. The number of `<Column>` children **must** match.
+
+## Content items
+
+### `Heading`
+| Prop | Type | Notes |
+|---|---|---|
+| `headingType` / `level` | `"h1"`–`"h6"` | `level` is an alias |
+| `text` / children | string | heading text — **plain string only** |
+| `fontSize` | string | `"22px"` |
+| `fontWeight` | number | `400`, `700` |
+| `color` | string | |
+| `lineHeight` | string | `"110%"`, `"1.3"` |
+| `letterSpacing` | string | `"0.06em"`, `"0.5px"` |
+| `textAlign` | `"left"`/`"center"`/`"right"` | |
+| `fontFamily` | `{ label, value }` | object |
+
+Use Heading for **any prominent number/amount**, never Paragraph.
+
+### `Paragraph`
+| Prop | Type | Notes |
+|---|---|---|
+| `html` | string | rich text with `<b> <i> <u> <a> <code>` etc. — use this for any formatting |
+| `text` / children | string | plain text (no tags) |
+| `fontSize` | string | `"14px"` |
+| `color` | string | |
+| `lineHeight` | string | `"140%"` |
+| `textAlign` / `fontFamily` | | |
+
+### `Button`
+| Prop | Type | Notes |
+|---|---|---|
+| `href` | string \| `{ name, values:{ href, target } }` | plain string auto-wrapped |
+| `backgroundColor` / `color` | string | |
+| `hoverBackgroundColor` / `hoverColor` | string | |
+| `fontSize` (string) / `fontWeight` (number) / `fontFamily` (object) | | |
+| `padding` | string | `"14px 28px"` |
+| `borderRadius` | string | `"8px"`, `"500px"` (pill) |
+| `textAlign` | | |
+
+By default a button is content-sized. For a **fixed / full-width** button, set the display width via the escape hatch: `values={{ size: { autoWidth: false, width: "100%" } }}` (or `"200px"`).
+
+### `Image`
+| Prop | Type | Notes |
+|---|---|---|
+| `src` | string \| `{ url, width?, height?, autoWidth?, maxWidth? }` | `width`/`height` = **natural** size |
+| `alt` / `altText` | string | |
+| `textAlign` | | |
+| `action` | `{ name:"web", values:{ href, target } }` | wrap image in a link |
+
+Default is **responsive** (fills the column, capped at natural size). For a **fixed display size**, set it on the src object: `src={{ url, autoWidth: false, maxWidth: "50%" }}` (a percent of the container). Hero images cap at ~500px wide.
+
+### `Divider`
+`borderTopWidth` `"1px"` · `borderTopColor` `"#BBBBBB"` · `borderTopStyle` `"solid"` · `textAlign`.
+
+### `Social`
+`icons={[{ name: "Facebook", url: "https://…" }]}` · `iconType` `"circle"`/`"rounded"`/`"squared"` · `iconSize` `32` · `spacing` `10` · `align`.
+
+### `Menu`
+`items={[{ text: "Home", href: "/" }]}` · `layout` `"horizontal"`/`"vertical"` · `separator` `"|"` · `align`.
+
+### `Table`
+For **real tabular data only**: `headers={["A","B"]}` · `data={[["1","2"]]}` · `columns` · `rows` · `enableHeader`. ⚠️ The shorthand renders a bordered, unpadded grid — do **not** use it for "details" or "line items"; use label/value Rows instead (see `patterns.md`).
+
+### `Video`
+`videoUrl="https://youtube.com/watch?v=…"` (auto-parsed) or `video={{ type, videoId, thumbnail }}`.
+
+### `Html`
+`html="<p>Custom HTML</p>"` — raw passthrough.
+
+## Rendering
+
+```tsx
+import { renderToHtml, renderToJson } from '@unlayer/react-elements';
+const html = renderToHtml(<Email>…</Email>); // HTML string
+const json = renderToJson(<Email>…</Email>); // Unlayer design JSON
+```
+
+## Common gotchas
+
+- `fontFamily` must be the `{ label, value }` object. `fontWeight` is a number; `fontSize`/`padding`/`lineHeight`/`letterSpacing` are strings with units.
+- Column count must match the Row layout, or the row renders empty.
+- `Image` `width`/`height` are the natural size; for a fixed display set `autoWidth:false` + a percent `maxWidth` on the src object.
+- `<Table headers/data>` = ugly spreadsheet — avoid for details; use label/value Rows.
+- Heading/Paragraph children must be a plain string — use `Paragraph html` for inline formatting.

--- a/unlayer-elements/references/patterns.md
+++ b/unlayer-elements/references/patterns.md
@@ -1,0 +1,138 @@
+# Unlayer Elements — Section Recipes
+
+Ready-to-use building blocks for emails that look genuinely premium, not "agent-generated." Pick a real brand palette; put white content rows on a light-gray `Email backgroundColor` for a card feel; keep 40–48px horizontal padding with intentional vertical rhythm. All shapes here are verified against `@unlayer/react-elements` `0.1.9+`.
+
+All Rows must be **direct children of the root** — when you factor a section into a helper, the helper must `return` a `<Row>` and be called inline (`{section(...)}`), never used as `<section/>`.
+
+## Brand header (logo)
+
+```tsx
+<Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="28px 40px 12px 40px">
+  <Column>
+    {/* a real logo image, or a styled wordmark for reliability */}
+    <Heading headingType="h2" fontSize="22px" fontWeight={700} color={BRAND} textAlign="left">brandname</Heading>
+  </Column>
+</Row>
+```
+
+## Hero: eyebrow + headline + subhead + CTA
+
+```tsx
+<Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="20px 40px 4px 40px">
+  <Column>
+    <Heading headingType="h4" fontSize="12px" fontWeight={700} color={BRAND} letterSpacing="0.08em">NEW</Heading>
+    <Heading headingType="h1" fontSize="32px" fontWeight={700} color={INK} lineHeight="118%">Your headline here</Heading>
+    <Paragraph html="A short, warm one-liner that sets up the value." fontSize="16px" color={MUTED} lineHeight="155%" />
+  </Column>
+</Row>
+<Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="20px 40px 32px 40px">
+  <Column>
+    {/* full-width CTA: set the display width on size via the escape hatch */}
+    <Button values={{ size: { autoWidth: false, width: '100%' } }} href="#" backgroundColor={BRAND} color="#FFFFFF"
+      fontSize="16px" fontWeight={700} padding="15px 28px" borderRadius="10px" textAlign="center">Get started</Button>
+  </Column>
+</Row>
+```
+
+## Details / line-items — label/value rows (NOT a Table)
+
+The single most important recipe. `Table` shorthand renders an ugly bordered spreadsheet; build clean rows with a hairline drawn by the Column's `border` object.
+
+```tsx
+const HAIRLINE = { borderBottomWidth: '1px', borderBottomStyle: 'solid', borderBottomColor: '#EBEBEB' };
+function detailRow(label: string, value: string, last = false) {
+  const cell = { padding: '14px 0', border: last ? undefined : HAIRLINE };
+  return (
+    <Row layout={ColumnLayouts.TwoEqual} backgroundColor="#FFFFFF" padding="0 40px">
+      <Column {...cell}><Paragraph html={label} fontSize="14px" color={MUTED} lineHeight="140%" /></Column>
+      <Column {...cell}><Paragraph html={`<b>${value}</b>`} fontSize="14px" color={INK} textAlign="right" lineHeight="140%" /></Column>
+    </Row>
+  );
+}
+
+// usage:
+{detailRow("Order", "#2705-0042")}
+{detailRow("Date", "Jul 1, 2026")}
+{detailRow("Total", "$65.50", true)}   // last row: no divider, often bolder/bigger
+```
+
+Add a section label above it:
+
+```tsx
+<Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="16px 40px 2px 40px">
+  <Column><Heading headingType="h4" fontSize="12px" fontWeight={700} color={MUTED} letterSpacing="0.06em">SUMMARY</Heading></Column>
+</Row>
+```
+
+## Feature grid (2×2)
+
+```tsx
+<Row layout={ColumnLayouts.TwoEqual} backgroundColor="#FFFFFF" padding="24px 40px 8px 40px">
+  <Column>
+    <Heading headingType="h3" fontSize="17px" fontWeight={700} color={INK}>Feature one</Heading>
+    <Paragraph html="One clear sentence about it." fontSize="14px" color={MUTED} lineHeight="155%" />
+  </Column>
+  <Column>
+    <Heading headingType="h3" fontSize="17px" fontWeight={700} color={INK}>Feature two</Heading>
+    <Paragraph html="One clear sentence about it." fontSize="14px" color={MUTED} lineHeight="155%" />
+  </Column>
+</Row>
+```
+
+## Stat / metric row (3 numbers)
+
+```tsx
+<Row layout={ColumnLayouts.ThreeEqual} backgroundColor="#FFFFFF" padding="0 40px">
+  <Column>
+    <Heading headingType="h2" fontSize="28px" fontWeight={700} color={INK} textAlign="center">1.2M</Heading>
+    <Paragraph html="API calls" fontSize="12px" color={MUTED} textAlign="center" />
+  </Column>
+  {/* repeat */}
+</Row>
+```
+
+Numbers are **always `<Heading>`** — a Paragraph's margin scales with font size and balloons the layout.
+
+## A fixed-size / centered image
+
+```tsx
+<Image src={{ url: 'https://…/logo.png', autoWidth: false, maxWidth: '50%' }} altText="Logo" textAlign="center" />
+```
+
+`width`/`height` on the src object are the **natural** size and stay responsive; `autoWidth:false` + a percent `maxWidth` pins the display size. (Hero images cap at ~500px wide.)
+
+## Section divider
+
+```tsx
+<Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="0 40px">
+  <Column><Divider borderTopWidth="1px" borderTopColor="#EBEBEB" borderTopStyle="solid" /></Column>
+</Row>
+```
+
+## Footer (links / social / legal)
+
+```tsx
+<Row layout={ColumnLayouts.OneColumn} padding="20px 40px 40px 40px">
+  <Column>
+    <Menu items={[{ text: "Docs", href: "#" }, { text: "Unsubscribe", href: "#" }]} layout="horizontal" separator="·" align="center" />
+    <Paragraph html="Company · City, State" fontSize="12px" color={MUTED} textAlign="center" />
+  </Column>
+</Row>
+```
+
+## Palette starters
+
+| Brand vibe | Background | Accent | Ink | Muted | Hairline |
+|---|---|---|---|---|---|
+| Light SaaS | `#F6F9FC` | `#635BFF` | `#1A1F36` | `#697386` | `#E3E8EE` |
+| Warm consumer | `#F7F7F7` | `#FF385C` | `#222222` | `#717171` | `#EBEBEB` |
+| Dark / music | `#121212` | `#1ED760` | `#FFFFFF` | `#B3B3B3` | `#2A2A2A` |
+
+## Do / Don't
+
+- ✅ Label/value Rows with a Column `border` hairline. ❌ `<Table headers/data>` for details.
+- ✅ `<Heading>` for amounts/stats. ❌ `<Paragraph>` for big numbers.
+- ✅ `Paragraph html="… <b>x</b> <a href>…"` for inline formatting. ❌ JSX children with tags (won't render).
+- ✅ Fixed image via `src={{ url, autoWidth:false, maxWidth:"50%" }}`. ❌ a px `width` expecting a fixed box (it's the natural size; default is responsive).
+- ✅ object `fontFamily={{ label, value }}`, number `fontWeight`, string `fontSize`. ❌ string `fontFamily` / bare-number sizes.
+- ✅ eyebrow + bold headline + generous padding. ❌ flat text on a single background with cramped spacing.

--- a/unlayer/SKILL.md
+++ b/unlayer/SKILL.md
@@ -26,7 +26,8 @@ Unlayer is a visual drag-and-drop editor for emails, web pages, popups, and docu
 
 | Task | Skill | Use When |
 |------|-------|----------|
-| **Framework setup** | `unlayer-integration` | Adding Unlayer to React, Vue, Angular, or plain JavaScript |
+| **Framework setup** | `unlayer-integration` | Adding the drag-and-drop editor to React, Vue, Angular, or plain JavaScript |
+| **Build templates in code** | `unlayer-elements` | Generating emails/pages/documents with React components, no visual editor (AI generation, programmatic templates) |
 | **Custom tools** | `unlayer-custom-tools` | Building custom drag-and-drop tools, property editors, widgets |
 | **Exporting content** | `unlayer-export` | HTML/PDF/Image export, saving designs, auto-save, Cloud API |
 | **Editor configuration** | `unlayer-config` | Features, appearance, merge tags, security, file storage |
@@ -36,11 +37,14 @@ Unlayer is a visual drag-and-drop editor for emails, web pages, popups, and docu
 | User Says | Route To |
 |-----------|----------|
 | "Add Unlayer to my React/Vue/Angular app" | `unlayer-integration` |
+| "Build an email/page in code" / "Generate a template with React components" / "Render JSX to email HTML" | `unlayer-elements` |
 | "Create a custom drag-and-drop tool" | `unlayer-custom-tools` |
 | "Export HTML" / "Save the design" / "Generate thumbnail" | `unlayer-export` |
 | "Set up merge tags" / "Configure features" / "HMAC security" | `unlayer-config` |
 | "Upload images to my server" / "Dark theme" / "Custom fonts" | `unlayer-config` |
 | "My merge tags aren't working" / "Editor won't load" | Check `unlayer-config` or `unlayer-integration` |
+
+> **Editor vs Elements:** `unlayer-integration` embeds the visual drag-and-drop editor. `unlayer-elements` builds templates purely in code (React components → HTML), with no editor UI — use it for AI/programmatic template generation.
 
 **Multiple skills needed?** Common flow:
 1. Start with `unlayer-integration` to add the editor to your app


### PR DESCRIPTION
A new sub-skill for @unlayer/react-elements — building emails, pages, and documents in code with React components (no visual editor). Covers the strict structure (Email/Page/Document > Row > Column > items), rendering with renderToHtml/renderToJson, the canonical prop shapes, the image sizing model (natural size + responsive default, object src autoWidth:false + percent maxWidth for a fixed size), and recipes for emails that look good (label/value rows with a Column border hairline instead of the Table shorthand, brand palettes, eyebrows, escape-hatch full-width button).

Every recipe and claim is verified against the published @unlayer/react-elements 0.1.9 (and the upcoming release) — uses only forms that work today. Includes references for full component prop tables and section patterns; registers the skill in the router and README.