### PR TITLE
Fix unlayer-elements full-width button recipe + target 0.1.11

### DIFF
--- a/unlayer-elements/SKILL.md
+++ b/unlayer-elements/SKILL.md
@@ -30,7 +30,7 @@ npm view @unlayer/react-elements version   # verify the published version first
 npm install @unlayer/react-elements
 ```
 
-> This skill is written for `@unlayer/react-elements` **0.1.9+** and uses only forms verified against it. Always pass **canonical prop shapes** (object `fontFamily`, string sizes, etc.) — they work in every version.
+> This skill targets `@unlayer/react-elements` **0.1.11+** (`npm view @unlayer/react-elements version` to check) and uses only forms verified against it. The natural forms below — string/number sizes, object or string `fontFamily`, factored-out style objects — all type-check on 0.1.11+; on older versions, upgrade.
 
 ## Mental model — the structure is strict
 
@@ -54,6 +54,8 @@ import { renderToHtml, renderToJson } from '@unlayer/react-elements';
 const html = renderToHtml(<Email>…</Email>);   // final HTML string (no hydration markers)
 const json = renderToJson(<Email>…</Email>);   // Unlayer design JSON (import into the editor)
 ```
+
+> Pass the **root element** (`<Email>`/`<Page>`/`<Document>`) directly. If you wrap your template in your own component, **call it** — `renderToJson(MyEmail())` — don't pass `<MyEmail />` (the renderers read the root element type, so a wrapper component isn't recognized).
 
 ## Complete example
 
@@ -138,9 +140,9 @@ Agent-generated emails often look cheap. To make them genuinely nice:
 - Use the brand's **real palette**; put white content rows on a light-gray `Email backgroundColor` for a card feel.
 - Add an **eyebrow**: a small uppercase `<Heading fontSize="12px" fontWeight={700} letterSpacing="0.08em">` in an accent color above the headline.
 - Generous, consistent **40–48px horizontal padding** and intentional vertical rhythm. Solid brand CTA with `borderRadius` ~8–10px.
-- **Full-width button** (when you want one) — set the display width on `size` via the escape hatch:
+- **Full-width button** (when you want one) — pass the top-level `width` prop (`"100%"`, or `"200px"` for a fixed width):
   ```tsx
-  <Button values={{ size: { autoWidth: false, width: '100%' } }} href="…" backgroundColor="…" color="#FFFFFF"
+  <Button width="100%" href="…" backgroundColor="…" color="#FFFFFF"
     fontSize="16px" fontWeight={700} padding="14px 28px" borderRadius="8px" textAlign="center">Get started</Button>
   ```
 

--- a/unlayer-elements/references/component-reference.md
+++ b/unlayer-elements/references/component-reference.md
@@ -1,6 +1,6 @@
 # Unlayer Elements — Component Reference
 
-All components import from `@unlayer/react-elements`. Use the **canonical prop shapes** below — they work in every published version (`0.1.9+`).
+All components import from `@unlayer/react-elements`. Use the prop shapes below — verified against `@unlayer/react-elements` `0.1.11+`.
 
 ## Root wrappers — `Email` / `Page` / `Document`
 
@@ -77,7 +77,7 @@ Use Heading for **any prominent number/amount**, never Paragraph.
 | `borderRadius` | string | `"8px"`, `"500px"` (pill) |
 | `textAlign` | | |
 
-By default a button is content-sized. For a **fixed / full-width** button, set the display width via the escape hatch: `values={{ size: { autoWidth: false, width: "100%" } }}` (or `"200px"`).
+By default a button is content-sized. For a **fixed / full-width** button, pass the top-level `width` prop: `width="100%"` (or `"200px"`).
 
 ### `Image`
 | Prop | Type | Notes |

--- a/unlayer-elements/references/patterns.md
+++ b/unlayer-elements/references/patterns.md
@@ -1,6 +1,6 @@
 # Unlayer Elements — Section Recipes
 
-Ready-to-use building blocks for emails that look genuinely premium, not "agent-generated." Pick a real brand palette; put white content rows on a light-gray `Email backgroundColor` for a card feel; keep 40–48px horizontal padding with intentional vertical rhythm. All shapes here are verified against `@unlayer/react-elements` `0.1.9+`.
+Ready-to-use building blocks for emails that look genuinely premium, not "agent-generated." Pick a real brand palette; put white content rows on a light-gray `Email backgroundColor` for a card feel; keep 40–48px horizontal padding with intentional vertical rhythm. All shapes here are verified against `@unlayer/react-elements` `0.1.11+`.
 
 All Rows must be **direct children of the root** — when you factor a section into a helper, the helper must `return` a `<Row>` and be called inline (`{section(...)}`), never used as `<section/>`.
 
@@ -27,8 +27,8 @@ All Rows must be **direct children of the root** — when you factor a section i
 </Row>
 <Row layout={ColumnLayouts.OneColumn} backgroundColor="#FFFFFF" padding="20px 40px 32px 40px">
   <Column>
-    {/* full-width CTA: set the display width on size via the escape hatch */}
-    <Button values={{ size: { autoWidth: false, width: '100%' } }} href="#" backgroundColor={BRAND} color="#FFFFFF"
+    {/* full-width CTA: pass the top-level width prop */}
+    <Button width="100%" href="#" backgroundColor={BRAND} color="#FFFFFF"
       fontSize="16px" fontWeight={700} padding="15px 28px" borderRadius="10px" textAlign="center">Get started</Button>
   </Column>
 </Row>


### PR DESCRIPTION
Surfaced by testing fresh agents that generate designs from this skill.

## What
- **Full-width button recipe was wrong.** It recommended `values={{ size: { autoWidth: false, width: '100%' } }}` — an escape hatch that **doesn't type-check under strict** (the `values` object would need the full `ButtonValues` shape) and steers agents toward non-compiling code. Replaced with the first-class **`width="100%"`** prop in `SKILL.md`, `patterns.md`, and `component-reference.md`.
- **Render note added.** `renderToHtml`/`renderToJson` take the root element directly — if you wrap your template in your own component, call it (`renderToJson(MyEmail())`), don't pass `<MyEmail/>`. (Multiple agents tripped on this.)
- **Version bumped to 0.1.11+.** That's where the relaxed input types landed, so the factored-out style objects in these recipes type-check without `as const`.

## Why
Doc-only. Multiple cold-start Opus agents building emails from this skill hit the button recipe (it doesn't compile) and the `renderToJson` wrapper-root requirement. These changes make the recipes match what actually compiles and renders on the current published version.